### PR TITLE
Install Firefox flatpak as the default browser

### DIFF
--- a/10-kitten/gnome/Containerfile
+++ b/10-kitten/gnome/Containerfile
@@ -14,6 +14,8 @@ RUN /scripts/console-login-helper-messages-remove.sh
 
 RUN /scripts/flathub-repo.sh
 
+RUN /scripts/flatpak-preinstall.sh
+
 RUN /scripts/bootc-update-noapply.sh
 
 RUN /scripts/lint.sh

--- a/10-kitten/plasma/Containerfile
+++ b/10-kitten/plasma/Containerfile
@@ -18,6 +18,8 @@ RUN /scripts/fedora-branding-remove.sh
 
 RUN /scripts/flathub-repo.sh
 
+RUN /scripts/flatpak-preinstall.sh
+
 RUN /scripts/bootc-update-noapply.sh
 
 RUN /scripts/lint.sh

--- a/scripts/flatpak-preinstall.sh
+++ b/scripts/flatpak-preinstall.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p \
+    /etc/flatpak/preinstall.d
+
+cat << EOF > /etc/flatpak/preinstall.d/firefox.preinstall
+[Flatpak Preinstall org.mozilla.firefox]
+Branch=stable
+EOF
+
+flatpak preinstall -y

--- a/scripts/gnome-desktop.sh
+++ b/scripts/gnome-desktop.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 dnf install -y \
+    -x firefox \
     @"Workstation"
 
 systemctl enable gdm

--- a/scripts/plasma-desktop.sh
+++ b/scripts/plasma-desktop.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 
 dnf install -y \
     -x plasma-discover-packagekit \
-    @"KDE Plasma Workspaces" \
-    falkon
+    @"KDE Plasma Workspaces"
 
 sed -i \
     's,Image=Next,Image=Alma-default,g' \


### PR DESCRIPTION
Install Firefox flatpak using `flatpak preinstall`.
https://gitlab.com/redhat/centos-stream/rpms/flatpak/-/blob/c10s/flatpak-add-support-for-preinstalling-flatpaks.patch

#6 